### PR TITLE
Ensure file exists changed when file is created

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -6,6 +6,8 @@
     owner: "{{ environment_file_owner }}"
     group: "{{ environment_file_group }}"
     state: touch
+  register: touch_log
+  changed_when: touch_log.diff.before.state != "file"
 
 - name: Remove previous values
   lineinfile:


### PR DESCRIPTION
It prevents this task from always sending a changed event even when the file exists.