### PR TITLE
No upper enforcement for key names

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -12,12 +12,12 @@
 - name: Remove previous values
   lineinfile:
     dest: "{{ environment_file }}"
-    regexp: '^{{ item.key | upper }}'
+    regexp: '^{{ item.key }}'
     state: absent
   with_dict: "{{ environment_config }}"
 
 - name: Configuring environment
   lineinfile:
     dest: "{{ environment_file }}"
-    line: "{{ item.key | upper }}='{{ item.value }}'"
+    line: "{{ item.key }}='{{ item.value }}'"
   with_dict: "{{ environment_config }}"


### PR DESCRIPTION
Linux is case sensitive and this also applies to env vars i.E.
`http_proxy`

CURL Reference here: https://curl.haxx.se/docs/manpage.html#ENVIRONMENT