### PR TITLE
change regex to match full key when removing it

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -12,7 +12,7 @@
 - name: Remove previous values
   lineinfile:
     dest: "{{ environment_file }}"
-    regexp: '^{{ item.key }}'
+    regexp: '^{{ item.key }}\ ?='
     state: absent
   with_dict: "{{ environment_config }}"
 


### PR DESCRIPTION
I had wrong key removal when keys have the same prefix like 'http_proxy' and 'http_proxy_request_fulluri' : 
'http_proxy_request_fulluri' is removed when matching regex '^http_proxy' if it appears first. Then 'http_proxy' is never matched with regex '^http_proxy_request_fulluri'.
So i modify the regex as '^{{ item.key }}\ ?=' to add an optional space and an equal char in the pattern to match.