### PR TITLE
Make "Configuring environment" task idempotent

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,15 +9,9 @@
   register: environment_file_result
   changed_when: environment_file_result.state != "file"
 
-- name: Remove previous values
-  lineinfile:
-    dest: "{{ environment_file }}"
-    regexp: '^{{ item.key }}\ ?='
-    state: absent
-  with_dict: "{{ environment_config }}"
-
 - name: Configuring environment
   lineinfile:
     dest: "{{ environment_file }}"
+    regexp: '^{{ item.key }}\ ?='
     line: "{{ item.key }}='{{ item.value }}'"
   with_dict: "{{ environment_config }}"


### PR DESCRIPTION
Hello!

"Remove previous values" and "Configuring environment" tasks isn't idempotent now and has "changed" state every play (even no changes really made):

```
TASK [weareinteractive.ansible-environment : Remove previous values] ***********
changed: [etcd3-2] => (item={'value': 3, 'key': u'ETCDCTL_API'})
changed: [etcd3-1] => (item={'value': 3, 'key': u'ETCDCTL_API'})
changed: [etcd3-3] => (item={'value': 3, 'key': u'ETCDCTL_API'})

TASK [weareinteractive.ansible-environment : Configuring environment] **********
changed: [etcd3-2] => (item={'value': 3, 'key': u'ETCDCTL_API'})
changed: [etcd3-1] => (item={'value': 3, 'key': u'ETCDCTL_API'})
changed: [etcd3-3] => (item={'value': 3, 'key': u'ETCDCTL_API'})
```

---

Advantages of this PR:

* Task will be idempotent. :slightly_smiling_face:

Disadvantages:

* Target file will can contain duplicates (because [lineinfile module](https://docs.ansible.com/ansible/latest/modules/lineinfile_module.html) with regex will change only last matched line). Looks not critical for me because shell will use last line too.